### PR TITLE
Use the final, new tag for the lipids portal

### DIFF
--- a/B. Communities/Lipids/allPathways.rq
+++ b/B. Communities/Lipids/allPathways.rq
@@ -1,5 +1,5 @@
 SELECT DISTINCT ?pathway (str(?title) as ?PathwayTitle)
 WHERE {
-?pathway wp:ontologyTag cur:LIPID_MAPS ; 
+?pathway wp:ontologyTag cur:Lipids ; 
 a wp:Pathway ; 
 dc:title ?title .}


### PR DESCRIPTION
This PR should not be merged before the Dec 2020 data is loaded into the SPARQL endpoint.