### PR TITLE
Fix query timeouts for GenesofPathway and MetabolitesofPathway

### DIFF
--- a/D. General/GenesofPathway.rq
+++ b/D. General/GenesofPathway.rq
@@ -5,10 +5,14 @@
 # param: pathwayId|autocomplete:pathway|WP1560|Pathway ID
 
 select distinct ?pathway (str(?label) as ?geneProduct) where {
+    {
+        SELECT ?pathwayRev ?pathway WHERE {
+            ?pathwayRev dcterms:identifier "{{pathwayId}}" .
+            ?pathwayRev a wp:Pathway .
+            ?pathwayRev dc:identifier ?pathway .
+        }
+    }
+    ?geneProduct dcterms:isPartOf ?pathwayRev .
     ?geneProduct a wp:GeneProduct .
     ?geneProduct rdfs:label ?label .
-    ?geneProduct dcterms:isPartOf ?pathwayRev .
-    ?pathwayRev a wp:Pathway .
-    ?pathwayRev dc:identifier ?pathway .
-    ?pathwayRev dcterms:identifier "{{pathwayId}}" .
 }

--- a/D. General/MetabolitesofPathway.rq
+++ b/D. General/MetabolitesofPathway.rq
@@ -5,9 +5,13 @@
 # param: pathwayId|autocomplete:pathway|WP1560|Pathway ID
 
 select distinct ?pathway (str(?label) as ?Metabolite) where {
+    {
+        SELECT ?pathway WHERE {
+            ?pathway dcterms:identifier "{{pathwayId}}" .
+            ?pathway a wp:Pathway .
+        }
+    }
     ?Metabolite a wp:Metabolite ;
        rdfs:label ?label ;
        dcterms:isPartOf ?pathway .
-    ?pathway a wp:Pathway ;
-    dcterms:identifier "{{pathwayId}}" .
 }


### PR DESCRIPTION
## Summary
- Use subquery to resolve pathway before joining gene products/metabolites
- Fixes timeout on GenesofPathway.rq and MetabolitesofPathway.rq
- Virtuoso was scanning all entities before filtering by pathway; subquery forces pathway resolution first

## Test plan
- [x] GenesofPathway with WP1560 returns results instantly
- [x] MetabolitesofPathway with WP1560 returns results instantly